### PR TITLE
Retry failed image load as vp8l

### DIFF
--- a/js/animator.js
+++ b/js/animator.js
@@ -248,6 +248,15 @@ var animator = animator || {};
     var image = new Image(this.w, this.h);
     this.framesInFlight++;
     image.src = blobURL;
+    image.onerror = function() {
+      if (image.triedvp8l)
+        return;
+      image.triedvp8l = true;
+      URL.revokeObjectURL(blobURL);
+      blob = webm.vp8tovp8l(blob);
+      blobURL = URL.createObjectURL(blob);
+      image.src = blobURL;
+    };
     image.onload = function() {
       var newCanvas = document.createElement('canvas');
       newCanvas.width = animator.w;
@@ -258,7 +267,7 @@ var animator = animator || {};
       URL.revokeObjectURL(blobURL);
       if (animator.loadFinishPending && animator.framesInFlight == 0)
         animator.loadFinished();
-    }
+    };
   };
 
   an.Animator.prototype.populate = function(frameOffset, width, height, frames) {

--- a/js/animator.js
+++ b/js/animator.js
@@ -151,6 +151,8 @@ var animator = animator || {};
       clearTimeout(this.playTimer);
     this.playTimer = null;
     this.snapshotContext.clearRect(0, 0, this.w, this.h);
+    if (this.frames.length)
+      this.snapshotContext.drawImage(this.frames[this.frames.length-1], 0, 0, this.w, this.h);
     this.snapshotCanvas.style.visibility = null;
     if (this.streamOn)
       this.video.play();
@@ -227,19 +229,12 @@ var animator = animator || {};
   };
 
   an.Animator.prototype.loadFinished = function() {
-    this.loadFinishPending = false;
     this.snapshotContext.clearRect(0, 0, this.w, this.h);
     if (this.frames.length) {
-      this.snapshotContext.drawImage(this.frames[this.frames.length-1], 0, 0);
+      this.snapshotContext.clearRect(0, 0, this.w, this.h);
+      this.snapshotContext.drawImage(this.frames[this.frames.length-1], 0, 0, this.w, this.h);
       this.startPlay();
     }
-  };
-
-  an.Animator.prototype.loadFinishCB = function() {
-    if (this.framesInFlight)
-      this.loadFinishPending = true;
-    else
-      this.loadFinished();
   };
 
   an.Animator.prototype.addFrameVP8 = function(frameOffset, blob, idx) {
@@ -248,8 +243,9 @@ var animator = animator || {};
     var image = new Image(this.w, this.h);
     this.framesInFlight++;
     image.src = blobURL;
-    image.onerror = function() {
+    image.onerror = function(e) {
       if (image.triedvp8l) {
+        console.log(e.type);
         animator.framesInFlight--;
         return;
       }
@@ -267,7 +263,7 @@ var animator = animator || {};
       animator.frames[frameOffset + idx] = newCanvas;
       animator.framesInFlight--;
       URL.revokeObjectURL(blobURL);
-      if (animator.loadFinishPending && animator.framesInFlight == 0)
+      if (animator.framesInFlight == 0)
         animator.loadFinished();
     };
   };
@@ -311,8 +307,7 @@ var animator = animator || {};
           data[i] = result.charCodeAt(i);
         webm.decode(data,
                     animator.setDimensions.bind(animator),
-                    animator.addFrameVP8.bind(animator, frameOffset),
-                    animator.loadFinishCB.bind(animator));
+                    animator.addFrameVP8.bind(animator, frameOffset));
         this.saved = true;
         animator.name = file.name.substring(0, file.name.length - 5);
         if (cb)

--- a/js/animator.js
+++ b/js/animator.js
@@ -249,8 +249,10 @@ var animator = animator || {};
     this.framesInFlight++;
     image.src = blobURL;
     image.onerror = function() {
-      if (image.triedvp8l)
+      if (image.triedvp8l) {
+        animator.framesInFlight--;
         return;
+      }
       image.triedvp8l = true;
       URL.revokeObjectURL(blobURL);
       blob = webm.vp8tovp8l(blob);

--- a/js/webm.js
+++ b/js/webm.js
@@ -1154,7 +1154,7 @@ var webm = webm || {};
   /* Public API begins here */
 
   webm.vp8tovp8l = function(blob) {
-    var vp8lHeader = [86, 80, 56, 76];  // ['V', 'P', '8', 'L']
+    var vp8lHeader = new Uint8Array([86, 80, 56, 76]);  // ['V', 'P', '8', 'L']
     blob = new Blob([blob.slice(0, 12), vp8lHeader, blob.slice(16)], {type: 'image/webp'});
     return blob;
   };
@@ -1206,7 +1206,7 @@ var webm = webm || {};
     return new Blob(chunks, {type: "video/webm"});
   };
 
-  webm.decode = function(data, sizeCB, frameCB, finishedCB) {
+  webm.decode = function(data, sizeCB, frameCB) {
     var riffHeader = new Uint8Array([82, 73, 70, 70]);  // 'RIFF'
     var webpHeader = new Uint8Array([87, 69, 66, 80]);  // 'WEBP'
     var vp8Header = new Uint8Array([86, 80, 56, 32]);  // 'VP8 '
@@ -1260,8 +1260,6 @@ var webm = webm || {};
         }
       }
     }
-    if (finishedCB)
-      finishedCB();
   };
 
   webm.verify = function(data, verbose) {

--- a/js/webm.js
+++ b/js/webm.js
@@ -1153,6 +1153,12 @@ var webm = webm || {};
 
   /* Public API begins here */
 
+  webm.vp8tovp8l = function(blob) {
+    var vp8lHeader = [86, 80, 56, 76];  // ['V', 'P', '8', 'L']
+    blob = new Blob([blob.slice(0, 12), vp8lHeader, blob.slice(16)], {type: 'image/webp'});
+    return blob;
+  };
+  
   webm.encode = function(title, w, h, frameDuration, frameCount, getFrameFunction) {
     frameDuration = Math.round(frameDuration);
     var framesPerCluster = Math.floor(32000 / frameDuration);


### PR DESCRIPTION
For a while, the app was generating broken webm files where the keyframes were encoded as VP8L (lossless VP8) rather than regular compressed VP8 forrmat.  Support loading the broken webm files by trying the VP8L header if loading it as VP8 doesn't work.