### PR TITLE
start dockerfile and CI to build it

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+.dockerignore

--- a/.github/workflows/buildDockerImage.yml
+++ b/.github/workflows/buildDockerImage.yml
@@ -1,0 +1,80 @@
+---
+name: buildDockerImage
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'
+  push:
+    branches:
+      - master
+    paths:
+      - .
+  pull_request:
+    branches:
+      - master
+    paths:
+      - .
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: szager/stop-motion
+  JUST_IMAGE_NAME: stop-motion
+
+jobs:
+  buildDockerImage:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Github Container registry
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          registry: ghcr.io
+
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: szager
+
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96
+        with:
+          tags: |
+            type=ref,event=pr
+            type=ref,event=branch
+            type=sha,format=long
+            type=raw,value=latest
+          images: |
+            ghcr.io/szager/stop-motion/${{ env.IMAGE_NAME }}
+            szager/${{ env.JUST_IMAGE_NAME }}
+      - name: Build Docker image (non master branch)
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        if: github.ref != 'refs/heads/master'
+        with:
+          context: .
+          file: Dockerfile
+          load: true
+          push: false
+
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }} 
+      - name: Build and push Docker image (master branch)
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        if: github.ref == 'refs/heads/master'
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:1.25.0
+
+COPY . /usr/share/nginx/html


### PR DESCRIPTION
This PR adds a docker file and github CI to build/push the docker image to the Github Container Registry and Docker Hub. This is a standard approach I take to building/maintaining docker images, and I am happy to discuss and fine tune this to work with your project.

If you do not have a dockerhub account, you will need to create one (I hard coded the name `szager` into the CI definition) You will need to create a secret in your repo named `DOCKERHUB_TOKEN`, which contains a [PAT](https://docs.docker.com/docker-hub/access-tokens/) with write access.

I have been running this on my fork for some time now. You can see what the [DockerHub looks like](https://hub.docker.com/repository/docker/bmcclure89/stop-motion/general), and the ghcr is accessible from the [packages](https://github.com/brandonmcclure/stop-motion/pkgs/container/stop-motion%2Fbrandonmcclure%2Fstop-motion) on [my fork of this repo](https://github.com/brandonmcclure/stop-motion) I personally like publishing the images in multiple locations to prevent vendor lock in. Some people prefer to only publish in one place to reduce confusion. 